### PR TITLE
Add dark theme to Enhanced Mouli

### DIFF
--- a/Enhanced Mouli/Chrome/content.js
+++ b/Enhanced Mouli/Chrome/content.js
@@ -4,14 +4,14 @@ const expandedSkills = {};
 let settings = {
   autoExpand: false,
   highContrast: false,
-  darkTheme: false // P7b8b
+  darkTheme: false
 };
 
-chrome.storage.local.get(['autoExpand', 'highContrast', 'darkTheme'], (result) => { // P7b8b
+chrome.storage.local.get(['autoExpand', 'highContrast', 'darkTheme'], (result) => {
   settings.autoExpand = result.autoExpand || false;
   settings.highContrast = result.highContrast || false;
-  settings.darkTheme = result.darkTheme || false; // P7b8b
-  applyTheme(); // P7b8b
+  settings.darkTheme = result.darkTheme || false;
+  applyTheme();
 });
 
 chrome.storage.onChanged.addListener((changes) => {
@@ -22,9 +22,10 @@ chrome.storage.onChanged.addListener((changes) => {
     settings.highContrast = changes.highContrast.newValue;
     updatePercentages();
   }
-  if (changes.darkTheme) { // P7b8b
-    settings.darkTheme = changes.darkTheme.newValue; // P7b8b
-    applyTheme(); // P7b8b
+  if (changes.darkTheme) {
+    settings.darkTheme = changes.darkTheme.newValue;
+    applyTheme();
+    refreshPage();
   }
 });
 
@@ -122,15 +123,15 @@ const styles = `
   font-weight: bold;
 }
 
-/* Dark theme styles */ // P1e62
-.dark-theme { // P1e62
-  --background: #0A1020; // P1e62
-  --surface: #141E33; // P1e62
-  --surface-light: #1C2942; // P1e62
-  --text: #F0F4FD; // P1e62
-  --text-secondary: #A1AECB; // P1e62
-  --border: #2A3654; // P1e62
-} // P1e62
+/* Dark theme styles */
+.dark-theme {
+  --background: #0A1020;
+  --surface: #141E33;
+  --surface-light: #1C2942;
+  --text: #F0F4FD;
+  --text-secondary: #A1AECB;
+  --border: #2A3654;
+}
 `;
 
 function injectStyles() {
@@ -139,13 +140,17 @@ function injectStyles() {
   document.head.appendChild(styleEl);
 }
 
-function applyTheme() { // P7b8b
-  if (settings.darkTheme) { // P7b8b
-    document.body.classList.add('dark-theme'); // P7b8b
-  } else { // P7b8b
-    document.body.classList.remove('dark-theme'); // P7b8b
-  } // P7b8b
-} // P7b8b
+function applyTheme() {
+  if (settings.darkTheme) {
+    document.body.classList.add('dark-theme');
+  } else {
+    document.body.classList.remove('dark-theme');
+  }
+}
+
+function refreshPage() {
+  location.reload();
+}
 
 function debugLog() {
   console.log("EnhancedMouli:", ...arguments);

--- a/Enhanced Mouli/Chrome/popup.js
+++ b/Enhanced Mouli/Chrome/popup.js
@@ -19,5 +19,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
   darkThemeCheckbox.addEventListener('change', function() { // P9d1f
     chrome.storage.local.set({ darkTheme: this.checked }); // P9d1f
+    chrome.tabs.query({ url: "https://my.epitech.eu/*" }, function(tabs) {
+      tabs.forEach(function(tab) {
+        chrome.tabs.reload(tab.id);
+      });
+    });
   }); // P9d1f
 });

--- a/Enhanced Mouli/Firefox/content.js
+++ b/Enhanced Mouli/Firefox/content.js
@@ -25,6 +25,7 @@ browser.storage.onChanged.addListener((changes) => {
   if (changes.darkTheme) {
     settings.darkTheme = changes.darkTheme.newValue;
     applyTheme();
+    refreshPage();
   }
 });
 
@@ -145,6 +146,10 @@ function applyTheme() {
   } else {
     document.body.classList.remove('dark-theme');
   }
+}
+
+function refreshPage() {
+  location.reload();
 }
 
 function debugLog() {

--- a/Enhanced Mouli/Firefox/popup.js
+++ b/Enhanced Mouli/Firefox/popup.js
@@ -19,5 +19,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     darkThemeCheckbox.addEventListener('change', function() {
       browser.storage.local.set({ darkTheme: this.checked });
+      browser.tabs.query({ url: "https://my.epitech.eu/*" }).then((tabs) => {
+        tabs.forEach((tab) => {
+          browser.tabs.reload(tab.id);
+        });
+      });
     });
   });


### PR DESCRIPTION
Implement a dark theme with automatic page refresh for Chrome and Firefox.

* Add dark theme styles in `Enhanced Mouli/Chrome/content.js` and `Enhanced Mouli/Firefox/content.js`.
* Add a function to refresh the page when the dark theme is toggled in `Enhanced Mouli/Chrome/content.js` and `Enhanced Mouli/Firefox/content.js`.
* Add an event listener to refresh the page when the dark theme is toggled in `Enhanced Mouli/Chrome/popup.js` and `Enhanced Mouli/Firefox/popup.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MyEcoria/Epitech-Addons/pull/2?shareId=0b9dd728-c155-4af3-b6e5-a2e541585cf6).